### PR TITLE
fix: error with SkinnedMeshRenderer without mesh

### DIFF
--- a/Editor/VRCHierarchyHighlighter.cs
+++ b/Editor/VRCHierarchyHighlighter.cs
@@ -316,7 +316,8 @@ public static class HierarchyIndentHelper
         target_rect.height = kIconSize;
 
         var mesh = ((SkinnedMeshRenderer)component).sharedMesh;
-        GUI.Label(target_rect, string.Format("Vers: {0}", mesh.vertexCount));
+        if (mesh)
+            GUI.Label(target_rect, string.Format("Vers: {0}", mesh.vertexCount));
     }
 }
 


### PR DESCRIPTION
AvatarOptimizerはMeshのないSkinnedMeshRendererを作成するためそれによってエラーが発生するようです

https://twitter.com/nagomizincoppe/status/1693665078753857907?s=20
https://twitter.com/nagomizincoppe/status/1693666632051441799?s=20

> VRCHierarchyHighlighterの「Show Vertexes：ON」で影響うけるっぽい。
> ※頂点数表示対象であるメッシュがきえるから？